### PR TITLE
Added more verbose message when an array payload is not passed to loadAll

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -484,6 +484,7 @@ BD.Store = Em.Object.extend({
         }
     },
     loadAll: function(type, dataItems) {
+        Ember.assert("You must pass an array when using loadAll.", Ember.typeOf(dataItems) == "array");
         var typeMap = this._typeMapFor(type);
         typeMap.allIsLoaded = true;
         BD.set('loadedAll.'+BD.pluralize(Em.get(type, 'root')), true);

--- a/tests/load/load-all.js
+++ b/tests/load/load-all.js
@@ -14,3 +14,13 @@ test('loadAll() should update BD.allLoaded', function() {
     App.Post.loadAll([]);
     ok(BD.get('loadedAll.posts'));
 });
+
+test('loadAll() should throw error with blank payload', function() {
+    throws(
+        function() {
+            App.Post.loadAll();
+        },
+        /You must pass an array when using loadAll\./,
+        "throws with just a message, no expected"
+    );
+});


### PR DESCRIPTION
It's not very obvious what the problem is when passing undefined or null to a model's loadAll method, especially when loading records manually from an AJAX server or the like. 
