### PR TITLE
Moves inflectors to external module

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,8 @@
     "jquery": "~2.0.3",
     "momentjs": "~2.3.1",
     "lodash": "~2.2.1",
-    "ember": "billysbilling/bower-ember#~1.3.0"
+    "ember": "billysbilling/bower-ember#~1.3.0",
+    "inflectors": "~1.0.2"
   },
   "version": "0.9.1",
   "homepage": "https://github.com/billysbilling/billy-data",

--- a/src/js/bd.js
+++ b/src/js/bd.js
@@ -1,3 +1,5 @@
+var inflectors = require('inflectors');
+
 window.BD = Ember.Namespace.create({
 
     typeNamespaces: [],
@@ -26,43 +28,11 @@ window.BD = Ember.Namespace.create({
         return type;
     },
 
-    plurals: {},
-    pluralize: function(name) {
-        if (this.plurals[name]) {
-            return this.plurals[name];
-        } else if (name.slice(-1) == 'y') {
-            return name.substring(0, name.length - 1)+'ies';
-        } else if (name.slice(-1) == 's') {
-            return name+'es';
-        } else if (name.slice(-3) == 'tch') {
-            return name+'es';
-        } else {
-            return name+'s';
-        }
-    },
-    singularize: function(name) {
-        if (!this.singulars) {
-            this.singulars = {};
-            for (var k in this.plurals) {
-                if (!this.plurals.hasOwnProperty(k)) continue;
-                this.singulars[this.plurals[k]] = k;
-            }
-        }
-        if (this.singulars[name]) {
-            return this.singulars[name];
-        } else if (name.slice(-3) == 'ies') {
-            return name.substring(0, name.length-3)+'y';
-        } else if (name.slice(-3) == 'ses') {
-            return name.substring(0, name.length-2);
-        } else if (name.slice(-5) == 'tches') {
-            return name.substring(0, name.length-2);
-        } else {
-            return name.substring(0, name.length-1);
-        }
-    },
-    classify: function(name) {
-        return name.substring(0, 1).toUpperCase()+name.substring(1);
-    },
+    addInflectorsRule: inflectors.addRule,
+    removeInflectorsRule: inflectors.removeRule,
+    pluralize: inflectors.pluralize,
+    singularize: inflectors.singularize,
+    classify: inflectors.classify,
 
     ajax: function(hash) {
         hash.url = BD.url(hash.url);
@@ -114,7 +84,7 @@ window.BD = Ember.Namespace.create({
         transaction.commit();
         return transaction;
     },
-    
+
     deleteRecords: function(records) {
         return BD.store.deleteRecords(records);
     },
@@ -122,7 +92,7 @@ window.BD = Ember.Namespace.create({
     printServerError: function(message) {
         console.error('Server error: ' + message);
     },
-    
+
     loadedAll: Em.Object.create()
 
 });

--- a/tests/bd.js
+++ b/tests/bd.js
@@ -19,3 +19,20 @@ test('Singularizer', function() {
     equal(BD.singularize('batches'), 'batch');
     equal(BD.singularize('bankLineMatches'), 'bankLineMatch');
 });
+
+test('Inflector rules', function() {
+    BD.addInflectorsRule('foo', 'bar');
+    equal(BD.pluralize('foo'), 'bar');
+    equal(BD.singularize('bar'), 'foo');
+    BD.removeInflectorsRule('foo');
+
+    BD.addInflectorsRule('foo2', 'bars');
+    BD.removeInflectorsRule('foo2');
+    equal(BD.pluralize('foo'), 'foos');
+    equal(BD.singularize('bars'), 'bar');
+});
+
+test('Classify', function() {
+    equal(BD.classify('invoice'), 'Invoice');
+    equal(BD.classify('bankLineMatch'), 'BankLineMatch');
+});


### PR DESCRIPTION
- Moves pluralize, singularize, and classify to Inflectors module
- Adds adding/deleting of plural rules
- Adds tests for classify and adding/deleting of plural rules

Overrides to rules (currently stored in BD.plurals) are moved inside the new Inflectors module. This means variables stored in BD.plurals will no longer be applied, but should instead be added by running BD.addInflectorsRule() with plural form as the first property and singular form as the second property. Likewise overrides can be deleted by running BD.removeInflectorsRule() with the plural form as the argument.
The change from a static overrides hash to methods will allow us to easily expand the add/remove rules functionality to support regular expressions.
