### PR TITLE
Added support for custom filters

### DIFF
--- a/src/js/adapters/fixture-adapter.js
+++ b/src/js/adapters/fixture-adapter.js
@@ -105,22 +105,30 @@ BD.FixtureAdapter = Em.Object.extend({
             if (query) {
                 for (var name in query) {
                     if (query.hasOwnProperty(name)) {
-                        //Don't filter if the property is not an attribute name or a belongs-to-relationship
-                        if (!Em.get(type, 'attributes').get(name) && !Em.get(type, 'belongsToRelationships').get(name.replace(/Id$/, ''))) {
-                            continue;
-                        }
-                        //|| name === 'pageSize' || name === 'offset' || name === 'include' || name === 'sortProperty' || name === 'sortDirection'
-                        var value = data[name],
-                            queryValue = query[name];
-                        if (Ember.typeOf(queryValue) === 'array') {
-                            if (!queryValue.contains(value)) {
+                        var queryValue = query[name],
+                            filter = type.getFilter(name);
+                        if (filter) {
+                            if (filter.callback(data, queryValue, query) === false) {
                                 match = false;
                                 break;
                             }
                         } else {
-                            if (value !== queryValue) {
-                                match = false;
-                                break;
+                            //Don't filter if the property is not an attribute name or a belongs-to-relationship
+                            if (!Em.get(type, 'attributes').get(name) && !Em.get(type, 'belongsToRelationships').get(name.replace(/Id$/, ''))) {
+                                continue;
+                            }
+                            //|| name === 'pageSize' || name === 'offset' || name === 'include' || name === 'sortProperty' || name === 'sortDirection'
+                            var value = data[name];
+                            if (Ember.typeOf(queryValue) === 'array') {
+                                if (!queryValue.contains(value)) {
+                                    match = false;
+                                    break;
+                                }
+                            } else {
+                                if (value !== queryValue) {
+                                    match = false;
+                                    break;
+                                }
                             }
                         }
                     }

--- a/src/js/model.js
+++ b/src/js/model.js
@@ -511,6 +511,23 @@ BD.Model.reopenClass({
     load: function(data) {
         return BD.store.load(this, data);
     },
+    
+    registerFilter: function(name, dependencies, callback) {
+        if (!this.filters) {
+            this.filters = {};
+        }
+        this.filters[name] = {
+            dependencies: dependencies,
+            callback: callback
+        };
+    },
+    
+    getFilter: function(name) {
+        if (!this.filters) {
+            return null;
+        }
+        return this.filters[name];
+    },
 
     registerSortMacro: function(name, dependencies, comparator) {
         if (!this.sortMacros) {

--- a/tests/adapters/fixture-adapter.js
+++ b/tests/adapters/fixture-adapter.js
@@ -13,7 +13,10 @@ QUnit.module('BD.FixtureAdapter', {
             posts: BD.hasMany('App.Post', 'category'),
             isPublic: BD.attr('boolean', {readonly: true})
         });
-        App.Category.registerSortMacro('macroTest', ['name'], function(a, b) {
+        App.Category.registerFilter('minLuckyNumber', ['luckyNumber'], function(data, minLuckyNumber, query) {
+            equal(minLuckyNumber, query.minLuckyNumber);
+            return Em.get(data, 'luckyNumber') >= minLuckyNumber;
+        });App.Category.registerSortMacro('macroTest', ['name'], function(a, b) {
             //Sort by char length of name
             return a.get('name').length - b.get('name').length;
         });
@@ -399,6 +402,34 @@ asyncTest('`findByQuery` sort using sort macro DESC', function() {
         equal(payload.categories[0].name, 'Billy');
         equal(payload.categories[1].name, 'Noah');
         start();
+    }, $.noop, $.noop);
+});
+
+asyncTest('`findByQuery` uses custom filters', function() {
+    var c = 3;
+    
+    adapter.findByQuery(BD.store, App.Category, {minLuckyNumber: 5}, function(payload) {
+        equal(payload.categories.length, 1);
+        equal(payload.categories[0].name, 'Billy');
+        if (--c === 0) {
+            start();
+        }
+    }, $.noop, $.noop);
+
+    adapter.findByQuery(BD.store, App.Category, {minLuckyNumber: 1}, function(payload) {
+        equal(payload.categories.length, 2);
+        equal(payload.categories[0].name, 'Billy');
+        equal(payload.categories[1].name, 'Noah');
+        if (--c === 0) {
+            start();
+        }
+    }, $.noop, $.noop);
+    
+    adapter.findByQuery(BD.store, App.Category, {minLuckyNumber: 78}, function(payload) {
+        equal(payload.categories.length, 0);
+        if (--c === 0) {
+            start();
+        }
     }, $.noop, $.noop);
 });
 

--- a/tests/filter.js
+++ b/tests/filter.js
@@ -9,6 +9,10 @@ QUnit.module('Filtered queries', {
             title: BD.attr('string'),
             isPublic: BD.attr('boolean')
         });
+        App.Post.registerFilter('authorStartsWith', ['author'], function(data, authorStartsWith, query) {
+            equal(authorStartsWith, query.authorStartsWith);
+            return Em.get(data, 'author').substring(0, authorStartsWith.length) === authorStartsWith;
+        });
         App.Post.registerSortMacro('macroTest', ['author', 'title'], function(a, b) {
             //Sort by combined char length of author and title
             return (a.get('author').length + a.get('title').length) - (b.get('author').length + b.get('title').length);
@@ -409,6 +413,25 @@ test('Test macro sorting DESC', function() {
     deepEqual(posts.mapProperty('id'), [1, 2, 3], 'Order should be correct');
     sebastian.set('author', '1');
     deepEqual(posts.mapProperty('id'), [2, 3, 1], 'Order should be correct');
+});
+
+test('Test custom filter', function() {
+    App.Post.loadAll([]);
+    
+    var adam = App.Post.find(2);
+    
+    var posts = App.Post.filter({
+        query: {
+            authorStartsWith: 'Seb'
+        }
+    });
+    
+    deepEqual(posts.get('queryObservers'), ['_all', 'author']);
+    deepEqual(posts.mapProperty('id'), [1], 'Sebastian should be there');
+    
+    adam.set('author', 'Sebulba');
+    
+    deepEqual(posts.mapProperty('id'), [1, 2], 'Sebastian and Sebulba should be there');
 });
 
 test('Test #bigdata sorting', function() {


### PR DESCRIPTION
Works both on filtered record arrays (with local data) and with the fixture adapter.

Usage:

``` javascript
App.Invoice.registerFilter(name, dependencies, callback);
```

Where `name` is the name of the filter, i.e. what the key name in the `query` object should be. `dependencies` is an array of property names that the filter uses. And `callback` is a function that takes the record's data, the value of `name` in the `query` object, and finally the `query` object itself.

Example:

``` javascript
App.Invoice.registerFilter('minEntryDate', ['entryDate'], function(data, minEntryDate, query) {
  minEntryDate === query.minEntryDate; //true
  return moment(Em.get(data, 'entryDate')).isAfter(minEntryDate);
});

App.Invoice.filter({
  query: {
    minEntryDate: '2014-03-02'
  }
});
```
